### PR TITLE
Add DialogUI Configuration Frame and Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,144 @@
-# DialogUI
+# 📜 DialogUI Enhanced
 
-Hi! this addon was made with the sole purpose of learning how to make wow addOns. This newer version uses Blizzard original code with some tweaks to properly handle icons natively, that's right, you read it right, now the gossip shows the icons that represent the option.
+> **A beautiful, enhanced fork of the original DialogUI addon**
 
-This should work with vanilla client or custom one like Turtle-WoW.
+**DialogUI Enhanced** is an improved fork of the original [DialogUI addon](https://github.com/Jslquintero/DialogUI) that transforms World of Warcraft's quest and gossip dialogs with a stunning parchment-themed interface. This fork adds powerful new features while maintaining the beautiful aesthetic that made the original so popular.
 
-<h3>My Gallery</h3>
+## 🌟 What's New in This Fork
 
-![image](https://github.com/user-attachments/assets/e8f119c3-cd0b-42ff-aa83-3d19dd23e76a)
-![image](https://github.com/user-attachments/assets/9182f8e1-173c-4893-974c-781adf200ad1)
-![image](https://github.com/user-attachments/assets/2efac0ce-e4c5-4cf7-8b75-c7eedaedad58)
-![image](https://github.com/user-attachments/assets/85c79713-e84a-45ad-8484-5d586b2220bc)
+This enhanced version builds upon the original DialogUI foundation and adds:
 
-[DialogueUI](https://www.curseforge.com/wow/addons/dialogueui) was obviously the inspiration for this new look.
+- **🎯 Movable Windows** - Drag quest and gossip windows anywhere on screen
+- **💾 Persistent Positioning** - Window positions are saved between game sessions  
+- **⚙️ Advanced Configuration Panel** - Beautiful in-game settings window with:
+  - Scale adjustment (0.5x to 2.0x)
+  - Transparency control (10% to 100%)
+  - Font size scaling (0.5x to 2.0x)
+- **🎨 Unified Parchment Theme** - All windows use consistent papiro aesthetic
+- **⌨️ ESC Key Support** - Press ESC or Decline to close quest windows properly
+- **🖼️ Enhanced Icon System** - Native gossip icons with proper fallback handling
 
-## Reporting an issue
+## 📸 Gallery
 
-Please before reporting any problem please disable all your addons just keep DialogUI active and try again, if the problem persists you are free to post the problem.
+<div style="display: flex; flex-wrap: wrap; gap: 10px; justify-content: center;">
+  <img src="https://raw.githubusercontent.com/Jslquintero/DialogUI/main/src/preview/Screenshot%20From%202025-06-18%2000-34-14.png" style="width: 30%; min-width: 200px;" />
+  <img src="https://raw.githubusercontent.com/Jslquintero/DialogUI/main/src/preview/Screenshot%20From%202025-06-18%2000-34-24.png" style="width: 30%; min-width: 200px;" />
+  <img src="https://raw.githubusercontent.com/Jslquintero/DialogUI/main/src/preview/Screenshot%20From%202025-06-18%2000-34-35.png" style="width: 30%; min-width: 200px;" />
+  <img src="https://raw.githubusercontent.com/Jslquintero/DialogUI/main/src/preview/Screenshot%20From%202025-06-18%2000-35-57.png" style="width: 30%; min-width: 200px;" />
+  <img src="https://raw.githubusercontent.com/Jslquintero/DialogUI/main/src/preview/Screenshot%20From%202025-06-18%2000-37-32.png" style="width: 30%; min-width: 200px;" />
+  <img src="https://raw.githubusercontent.com/Jslquintero/DialogUI/main/src/preview/Screenshot%20From%202025-06-18%2000-37-38.png" style="width: 30%; min-width: 200px;" />
+  <img src="https://raw.githubusercontent.com/Jslquintero/DialogUI/main/src/preview/Screenshot%20From%202025-06-18%2000-41-14.png" style="width: 30%; min-width: 200px;" />
+  <img src="https://raw.githubusercontent.com/Jslquintero/DialogUI/main/src/preview/Screenshot%20From%202025-06-18%2000-42-06.png" style="width: 30%; min-width: 200px;" />
+</div>
 
-### How to report an issue?
+## ⚡ Quick Start
 
-[issues page](https://github.com/Jslquintero/DialogUI/issues/new)
+1. **Install**: Extract to your `Interface/AddOns/` folder
+2. **Enable**: Activate "DialogUI" in your addon list
+3. **Configure**: Use `/dialogui` in chat to open settings
+4. **Enjoy**: Beautiful, movable quest and gossip windows!
 
-# Customize it!
+## 🎮 Commands
 
-Feel free to add/remove icons or change the frame background completely, every image is now Truevision Graphics Adapter (TGA) format.
+| Command | Description |
+|---------|-------------|
+| `/dialogui` | Open configuration window |
+| `/resetdialogs` | Reset all window positions |
+| `/debugdialogs` | Show debug information |
 
-I recommend using Gimp 3 with [Batcher](https://kamilburda.github.io/batcher/) to quickly export your new files.
+## 🔧 Compatibility
 
-To change the gossip icons you can go to :
+- ✅ **Vanilla WoW** (1.12.1)
+- ✅ **Turtle WoW** (Custom client)
+- ✅ **Classic Era** servers
+- ⚠️ Designed for English client (Spanish support can be added by editing gossip functions)
 
-> DialogUI/src/assets/art/icons/GossipIcons.xcf
+## 🎨 Original Inspiration
 
-To change the style of the buttons or of the frame :
+This addon was inspired by [DialogueUI](https://www.curseforge.com/wow/addons/dialogueui) and uses enhanced Blizzard original code with native icon handling.
 
-> DialogUI/src/assets/art/parchment/ParchmentLayout.xcf
+## 📋 About This Fork
+
+This is an **enhanced fork** of the original [DialogUI by Jslquintero](https://github.com/Jslquintero/DialogUI). The original author created an excellent foundation for learning WoW addon development. This fork aims to contribute new features and improvements back to the community while maintaining the beautiful parchment aesthetic that makes DialogUI special.
+
+**Original Author**: [Jslquintero](https://github.com/Jslquintero)  
+**Fork Maintainer**: [Your GitHub Username]  
+**Original Repository**: https://github.com/Jslquintero/DialogUI
+
+## 🐛 Reporting Issues
+
+## 🐛 Reporting Issues
+
+**Before reporting any issue:**
+1. Disable all other addons
+2. Keep only DialogUI active  
+3. Test if the problem persists
+4. If it does, please report it!
+
+### How to Report
+
+- **Original DialogUI Issues**: [Original Repository Issues](https://github.com/Jslquintero/DialogUI/issues/new)
+- **Enhanced Fork Issues**: [This Fork's Issues](https://github.com/jucsp/DialogUI/issues/new)
+
+Please specify which version you're using and include any error messages or screenshots.
+
+## 🎨 Customization
+
+Feel free to customize the look completely! Every image is in **TGA format** for easy editing.
+
+### 🖼️ Customize Icons
+Edit gossip icons at:
+```
+DialogUI/src/assets/art/icons/GossipIcons.xcf
+```
+
+### 🎨 Customize Frame Style  
+Edit button styles and frame backgrounds at:
+```
+DialogUI/src/assets/art/parchment/ParchmentLayout.xcf
+```
+
+### 🛠️ How to Edit
+
+1. **Add/Remove Icons**: All gossip icons are individual TGA files in `/src/assets/art/icons/`
+2. **Change Frame Background**: Edit the parchment textures and button styles
+3. **Export Process**: Use GIMP 3 with [Batcher plugin](https://kamilburda.github.io/batcher/) for quick TGA batch export
+
+**Recommended Tools:**
+- **GIMP 3** with [Batcher plugin](https://kamilburda.github.io/batcher/) for batch TGA export
+- Any image editor that supports TGA format
+
+**File Format**: All images must be in **Truevision Graphics Adapter (TGA)** format to work properly in WoW.
 
 ---
 
-# Español
+## 🌍 Español
 
-¡Hola! este addon fue hecho con la unica intención de aprender como hacer addons. Esta nueva versión utiliza el código original hecho por Blizzard pero se agregan algunas mejoras para poder mostrar los iconos de forma nativa, así es, leíste bien, ahora la ventana de diálogos ahora muestra los iconos representativos de cada opción.
+**DialogUI Enhanced** es una versión mejorada del addon original [DialogUI](https://github.com/Jslquintero/DialogUI) que transforma los diálogos de misiones y conversaciones de World of Warcraft con una hermosa interfaz temática de pergamino.
 
-Debe funcionar con el cliente vanilla o personalizado como Turtle-WoW.
+### ✨ Nuevas Funciones
 
-Pequeña nota:
+- **Ventanas móviles**: Arrastra las ventanas donde quieras
+- **Posiciones persistentes**: Se guardan entre sesiones
+- **Panel de configuración avanzado**: Escala, transparencia y tamaño de fuente
+- **Soporte para tecla ESC**: Cierra ventanas con ESC o Rechazar
+- **Tema unificado**: Todas las ventanas usan el mismo estilo de pergamino
 
-> El addon esta hecho para el cliente en ingles, si deseas
-> eres libre de editarlo para que utilice las opciones en español dentro
-> de la funcion DGossipFrameOptionsUpdate en gossip.frame.lua
+### 🎯 Comandos
 
-[DialogueUI](https://www.curseforge.com/wow/addons/dialogueui) fue obviamente mi inspiración.
+- `/dialogui` - Abrir ventana de configuración
+- `/resetdialogs` - Reiniciar posiciones de ventanas
+- `/debugdialogs` - Mostrar información de debug
 
-## Reportando un problema
+### 📝 Nota Importante
 
-Please before reporting any problem please disable all your addons just keep DialogUI active and try again, if the problem persists you are free to post the problem.
+El addon está optimizado para cliente en inglés. Para usarlo en español, edita las funciones de gossip en `gossip.frame.lua`.
 
-### ¿Cómo reporto un problema?
+---
 
-[página de problemas](https://github.com/Jslquintero/DialogUI/issues/new)
+## 📄 License
+
+This enhanced fork maintains the same spirit of learning and sharing as the original DialogUI project.
 
 # ¡Perzonalizar!
 

--- a/dialogUI.toc
+++ b/dialogUI.toc
@@ -1,10 +1,11 @@
 ## Interface: 11200
 ## Title: DialogUI
-## Author: Sxus
-## Version: 1.0.0
+## Author: Sxus, Kasper
+## Version: 1.1.0
 ## DefaultState: Enabled
 ## LoadOnDemand: 0
 ## Notes: Addon made for an immersive questing experience in vanilla client, consider it a Vanilla+ frame.
+## SavedVariables: DialogUIFramePosition, DialogUI_SavedConfig
 
 # Fonts used for the frames
 src\assets\font\fonts.xml
@@ -20,13 +21,15 @@ src\frames\uiPanelTemplate\ui.panel.template.lua
 src\frames\uiPanelTemplate\ui.panel.template.xml
 src\frames\uiPanelTemplate\ui.panel.template.button.xml
 
-
+# Quest frame (loaded first to provide basic functions)
+src\frames\questFrame\quest.frame.lua
+src\frames\questFrame\quest.frame.template.xml
+src\frames\questFrame\quest.frame.xml
 
 # Gossip frame
 src\frames\gossipFrame\gossip.frame.lua
 src\frames\gossipFrame\gossip.frame.xml
 
-# Quest frame
-src\frames\questFrame\quest.frame.lua
-src\frames\questFrame\quest.frame.template.xml
-src\frames\questFrame\quest.frame.xml
+# Configuration frame (loaded last to override basic functions)
+src\frames\configFrame\config.frame.lua
+src\frames\configFrame\config.frame.xml

--- a/src/frames/configFrame/config.frame.lua
+++ b/src/frames/configFrame/config.frame.lua
@@ -1,0 +1,373 @@
+---@diagnostic disable: undefined-global
+
+-- DialogUI Configuration System
+DialogUI_Config = {
+    scale = 1.0,        -- Frame scale (0.5 - 2.0)
+    alpha = 1.0,        -- Frame transparency (0.1 - 1.0)
+    fontSize = 1.0      -- Font size multiplier (0.5 - 2.0)
+};
+
+local COLORS = {
+    DarkBrown = {0.19, 0.17, 0.13},
+    LightBrown = {0.50, 0.36, 0.24},
+    Ivory = {0.87, 0.86, 0.75}
+};
+
+function SetFontColor(fontObject, key)
+    local color = COLORS[key];
+    fontObject:SetTextColor(color[1], color[2], color[3]);
+end
+
+-- Main Config Frame Functions
+function DConfigFrame_OnLoad()
+    -- Disable dragging since it's always centered
+    this:SetMovable(false);
+    this:EnableMouse(true);
+    
+    -- Set initial info text with available commands
+    local infoText = "Adjust the settings below to customize your DialogUI experience.\n\n" ..
+                    "Scale: Changes the size of all dialog windows (0.5 - 2.0)\n" ..
+                    "Transparency: Adjusts window background opacity (10% - 100%)\n" ..
+                    "Font Size: Changes text size in dialogs (0.5 - 2.0)\n\n" ..
+                    "Available Commands:\n" ..
+                    "/dialogui or /dialogui config - Opens this configuration window\n" ..
+                    "/dialogui reset - Resets all settings to default\n\n" ..
+                    "You can also edit values directly in the text boxes.\n" ..
+                    "Changes are applied immediately and saved automatically.";
+    DConfigInfoText:SetText(infoText);
+    SetFontColor(DConfigInfoText, "DarkBrown");
+end
+
+function DConfigFrame_OnShow()
+    PlaySound("igQuestListOpen");
+    
+    -- Always keep config frame at scale 1.0 and centered
+    DConfigFrame:SetScale(1.0);
+    DConfigFrame:ClearAllPoints();
+    DConfigFrame:SetPoint("CENTER", UIParent, "CENTER", 0, 0);
+    
+    -- Set label colors
+    local scaleLabel = getglobal("DConfigScaleLabel");
+    if scaleLabel then
+        SetFontColor(scaleLabel, "DarkBrown");
+    end
+    
+    local alphaLabel = getglobal("DConfigAlphaLabel");
+    if alphaLabel then
+        SetFontColor(alphaLabel, "DarkBrown");
+    end
+    
+    local fontLabel = getglobal("DConfigFontLabel");
+    if fontLabel then
+        SetFontColor(fontLabel, "DarkBrown");
+    end
+    
+    -- Update EditBox values (with safety checks)
+    local scaleEditBox = getglobal("DConfigScaleEditBox");
+    if scaleEditBox then
+        scaleEditBox:SetText(string.format("%.1f", DialogUI_Config.scale));
+    end
+    
+    local alphaEditBox = getglobal("DConfigAlphaEditBox");
+    if alphaEditBox then
+        alphaEditBox:SetText(tostring(math.floor(DialogUI_Config.alpha * 100)));
+    end
+    
+    local fontEditBox = getglobal("DConfigFontEditBox");
+    if fontEditBox then
+        fontEditBox:SetText(string.format("%.1f", DialogUI_Config.fontSize));
+    end
+    
+    -- Apply current transparency to config frame background
+    DialogUI_ApplyConfigAlpha();
+end
+
+function DConfigFrame_OnHide()
+    PlaySound("igQuestListClose");
+end
+
+-- EditBox Functions
+function DConfigScaleEditBox_OnEnterPressed()
+    local editBox = getglobal("DConfigScaleEditBox");
+    if not editBox then return; end
+    
+    local text = editBox:GetText();
+    -- Replace comma with dot for decimal support
+    text = string.gsub(text, ",", ".");
+    local value = tonumber(text);
+    
+    if value and value >= 0.5 and value <= 2.0 then
+        DialogUI_Config.scale = value;
+        editBox:SetText(string.format("%.1f", value));
+        DialogUI_ApplyScale();
+        DialogUI_SaveConfig();
+        editBox:ClearFocus();
+        DEFAULT_CHAT_FRAME:AddMessage("DialogUI: Scale set to " .. string.format("%.1f", value));
+    else
+        editBox:SetText(string.format("%.1f", DialogUI_Config.scale));
+        DEFAULT_CHAT_FRAME:AddMessage("DialogUI: Scale must be between 0.5 and 2.0 (example: 1.5)");
+    end
+end
+
+function DConfigAlphaEditBox_OnEnterPressed()
+    local editBox = getglobal("DConfigAlphaEditBox");
+    if not editBox then return; end
+    
+    local value = tonumber(editBox:GetText());
+    if value and value >= 10 and value <= 100 then
+        local alpha = value / 100;
+        DialogUI_Config.alpha = alpha;
+        editBox:SetText(tostring(value));
+        DialogUI_ApplyAlpha();
+        DialogUI_ApplyConfigAlpha();
+        DialogUI_SaveConfig();
+        editBox:ClearFocus();
+        DEFAULT_CHAT_FRAME:AddMessage("DialogUI: Transparency set to " .. value .. "%");
+    else
+        editBox:SetText(tostring(math.floor(DialogUI_Config.alpha * 100)));
+        DEFAULT_CHAT_FRAME:AddMessage("DialogUI: Transparency must be between 10 and 100 (whole numbers only)");
+    end
+end
+
+function DConfigFontEditBox_OnEnterPressed()
+    local editBox = getglobal("DConfigFontEditBox");
+    if not editBox then return; end
+    
+    local text = editBox:GetText();
+    -- Replace comma with dot for decimal support
+    text = string.gsub(text, ",", ".");
+    local value = tonumber(text);
+    
+    if value and value >= 0.5 and value <= 2.0 then
+        DialogUI_Config.fontSize = value;
+        editBox:SetText(string.format("%.1f", value));
+        DialogUI_ApplyFontSize();
+        DialogUI_SaveConfig();
+        editBox:ClearFocus();
+        DEFAULT_CHAT_FRAME:AddMessage("DialogUI: Font size set to " .. string.format("%.1f", value));
+    else
+        editBox:SetText(string.format("%.1f", DialogUI_Config.fontSize));
+        DEFAULT_CHAT_FRAME:AddMessage("DialogUI: Font size must be between 0.5 and 2.0 (example: 1.2)");
+    end
+end
+
+-- Button Functions
+function DConfigResetButton_OnClick()
+    -- Reset to default values
+    DialogUI_Config.scale = 1.0;
+    DialogUI_Config.alpha = 1.0;
+    DialogUI_Config.fontSize = 1.0;
+    
+    -- Update EditBoxes
+    local scaleEditBox = getglobal("DConfigScaleEditBox");
+    if scaleEditBox then
+        scaleEditBox:SetText("1.0");
+    end
+    
+    local alphaEditBox = getglobal("DConfigAlphaEditBox");
+    if alphaEditBox then
+        alphaEditBox:SetText("100");
+    end
+    
+    local fontEditBox = getglobal("DConfigFontEditBox");
+    if fontEditBox then
+        fontEditBox:SetText("1.0");
+    end
+    
+    -- Apply changes
+    DialogUI_ApplyAllSettings();
+    DialogUI_SaveConfig();
+    
+    DEFAULT_CHAT_FRAME:AddMessage("DialogUI: Settings reset to default");
+    PlaySound("igQuestListComplete");
+end
+
+function DConfigCloseButton_OnClick()
+    HideUIPanel(DConfigFrame);
+end
+
+-- Configuration Application Functions
+function DialogUI_ApplyScale()
+    local scale = DialogUI_Config.scale;
+    
+    -- Only apply scale to dialog frames, NOT config frame
+    if DQuestFrame then
+        DQuestFrame:SetScale(scale);
+    end
+    if DGossipFrame then
+        DGossipFrame:SetScale(scale);
+    end
+    -- Config frame keeps fixed scale of 1.0
+end
+
+function DialogUI_ApplyAlpha()
+    local alpha = DialogUI_Config.alpha;
+    
+    -- Apply transparency to quest frame and its panels
+    if DQuestFrame then
+        -- Apply to main quest frame background
+        DialogUI_ApplyAlphaToPanel(DQuestFrame, alpha);
+        
+        -- Apply to reward panel background
+        local rewardPanel = getglobal("DQuestFrameRewardPanel");
+        if rewardPanel then
+            DialogUI_ApplyAlphaToPanel(rewardPanel, alpha);
+        end
+        
+        -- Apply to progress panel background
+        local progressPanel = getglobal("DQuestFrameProgressPanel");
+        if progressPanel then
+            DialogUI_ApplyAlphaToPanel(progressPanel, alpha);
+        end
+        
+        -- Apply to greeting panel background
+        local greetingPanel = getglobal("DQuestFrameGreetingPanel");
+        if greetingPanel then
+            DialogUI_ApplyAlphaToPanel(greetingPanel, alpha);
+        end
+        
+        -- Apply to detail panel background
+        local detailPanel = getglobal("DQuestFrameDetailPanel");
+        if detailPanel then
+            DialogUI_ApplyAlphaToPanel(detailPanel, alpha);
+        end
+    end
+    
+    -- Apply transparency to gossip frame
+    if DGossipFrame then
+        DialogUI_ApplyAlphaToPanel(DGossipFrame, alpha);
+        
+        -- Apply to gossip greeting panel
+        local gossipGreetingPanel = getglobal("DGossipFrameGreetingPanel");
+        if gossipGreetingPanel then
+            DialogUI_ApplyAlphaToPanel(gossipGreetingPanel, alpha);
+        end
+    end
+    
+    -- Apply transparency to any money frames that might exist
+    local moneyFrame = getglobal("DQuestProgressRequiredMoneyFrame");
+    if moneyFrame then
+        DialogUI_ApplyAlphaToPanel(moneyFrame, alpha);
+    end
+    
+    -- Config frame transparency is handled separately by DialogUI_ApplyConfigAlpha()
+end
+
+-- Helper function to apply alpha to a panel's background texture
+function DialogUI_ApplyAlphaToPanel(panel, alpha)
+    if not panel then return; end
+    
+    local regions = {panel:GetRegions()};
+    for i = 1, table.getn(regions) do
+        local region = regions[i];
+        if region and region:GetObjectType() == "Texture" then
+            -- Apply alpha only to background textures (usually the first ones)
+            local texture = region:GetTexture();
+            if texture and (string.find(texture, "Parchment") or i == 1) then
+                region:SetAlpha(alpha);
+                -- Only apply to the first parchment texture found
+                break;
+            end
+        end
+    end
+end
+
+function DialogUI_ApplyFontSize()
+    local fontSize = DialogUI_Config.fontSize;
+    
+    -- Apply to quest frame fonts
+    if DQuestFrame then
+        DialogUI_ScaleFonts(DQuestFrame, fontSize);
+    end
+    
+    -- Apply to gossip frame fonts
+    if DGossipFrame then
+        DialogUI_ScaleFonts(DGossipFrame, fontSize);
+    end
+end
+
+function DialogUI_ScaleFonts(frame, scale)
+    if not frame then return; end
+    
+    -- Scale all FontString objects in the frame
+    local regions = {frame:GetRegions()};
+    for i = 1, table.getn(regions) do
+        local region = regions[i];
+        if region and region:GetObjectType() == "FontString" then
+            local fontName, fontSize, fontFlags = region:GetFont();
+            if fontName and fontSize then
+                region:SetFont(fontName, fontSize * scale, fontFlags);
+            end
+        end
+    end
+    
+    -- Recursively scale fonts in child frames
+    local children = {frame:GetChildren()};
+    for i = 1, table.getn(children) do
+        local child = children[i];
+        if child then
+            DialogUI_ScaleFonts(child, scale);
+        end
+    end
+end
+
+function DialogUI_ApplyAllSettings()
+    DialogUI_ApplyScale();
+    DialogUI_ApplyAlpha();
+    DialogUI_ApplyFontSize();
+end
+
+-- Configuration Saving/Loading (enhanced versions that override basic ones)
+function DialogUI_SaveConfig()
+    if not DialogUI_SavedConfig then
+        DialogUI_SavedConfig = {};
+    end
+    
+    DialogUI_SavedConfig.scale = DialogUI_Config.scale;
+    DialogUI_SavedConfig.alpha = DialogUI_Config.alpha;
+    DialogUI_SavedConfig.fontSize = DialogUI_Config.fontSize;
+end
+
+function DialogUI_LoadConfig()
+    if DialogUI_SavedConfig then
+        DialogUI_Config.scale = DialogUI_SavedConfig.scale or 1.0;
+        DialogUI_Config.alpha = DialogUI_SavedConfig.alpha or 1.0;
+        DialogUI_Config.fontSize = DialogUI_SavedConfig.fontSize or 1.0;
+        
+        -- Apply loaded settings
+        DialogUI_ApplyAllSettings();
+    end
+end
+
+-- Show/Hide Config Frame Functions (these will override the basic ones from quest.frame.lua)
+function DialogUI_ShowConfig()
+    ShowUIPanel(DConfigFrame);
+end
+
+function DialogUI_HideConfig()
+    HideUIPanel(DConfigFrame);
+end
+
+-- Config Frame specific transparency function
+function DialogUI_ApplyConfigAlpha()
+    local alpha = DialogUI_Config.alpha;
+    
+    -- Apply transparency only to the background parchment of config frame
+    if DConfigFrame then
+        local layers = {DConfigFrame:GetRegions()};
+        for i = 1, table.getn(layers) do
+            if layers[i]:GetObjectType() == "Texture" then
+                layers[i]:SetAlpha(alpha);
+                break; -- Only first texture which is the background
+            end
+        end
+    end
+end
+
+function DialogUI_ToggleConfig()
+    if DConfigFrame:IsVisible() then
+        DialogUI_HideConfig();
+    else
+        DialogUI_ShowConfig();
+    end
+end

--- a/src/frames/configFrame/config.frame.xml
+++ b/src/frames/configFrame/config.frame.xml
@@ -1,0 +1,254 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Script file="src\frames\configFrame\config.frame.lua" />
+    
+    <!-- EditBox Template for Config -->
+    <EditBox name="DConfigEditBoxTemplate" virtual="true" letters="5">
+        <Size>
+            <AbsDimension x="80" y="25" />
+        </Size>
+        <Layers>
+            <Layer level="BACKGROUND">
+                <Texture name="$parentBG" file="Interface\AddOns\DialogUI\src\assets\art\parchment\ButtonHighlight-Gossip">
+                    <Size>
+                        <AbsDimension x="80" y="25" />
+                    </Size>
+                    <Anchors>
+                        <Anchor point="CENTER" />
+                    </Anchors>
+                    <Color>
+                        <Color r="0.9" g="0.9" b="0.8" a="0.9" />
+                    </Color>
+                </Texture>
+            </Layer>
+        </Layers>
+        <FontString inherits="DQuestButtonTitleGossip" />
+        <Scripts>
+            <OnLoad>
+                this:SetAutoFocus(false);
+                this:SetNumeric(false);  -- Allow decimals
+            </OnLoad>
+            <OnEscapePressed>
+                this:ClearFocus();
+            </OnEscapePressed>
+        </Scripts>
+    </EditBox>
+
+    <!-- Config Frame -->
+    <Frame name="DConfigFrame" toplevel="true" parent="UIParent" movable="false" enableMouse="true" hidden="true">
+        <Size>
+            <AbsDimension x="400" y="500" />
+        </Size>
+        <Anchors>
+            <Anchor point="CENTER">
+                <Offset>
+                    <AbsDimension x="0" y="0" />
+                </Offset>
+            </Anchor>
+        </Anchors>
+        <Layers>
+            <Layer level="BACKGROUND">
+                <Texture file="Interface\AddOns\DialogUI\src\assets\art\parchment\Parchment">
+                    <Size x="400" y="500" />
+                </Texture>
+            </Layer>
+            <Layer level="ARTWORK">
+                <FontString name="DConfigFrameTitle" inherits="DQuestTitleFont" text="DialogUI Configuration" justifyH="CENTER">
+                    <Size>
+                        <AbsDimension x="350" y="25"/>
+                    </Size>
+                    <Anchors>
+                        <Anchor point="TOP">
+                            <Offset>
+                                <AbsDimension x="0" y="-30" />
+                            </Offset>
+                        </Anchor>
+                    </Anchors>
+                </FontString>
+                
+                <!-- Information Text -->
+                <FontString name="DConfigInfoText" inherits="DQuestFont" justifyH="LEFT">
+                    <Size>
+                        <AbsDimension x="350" y="120"/>
+                    </Size>
+                    <Anchors>
+                        <Anchor point="TOP" relativeTo="DConfigFrameTitle" relativePoint="BOTTOM">
+                            <Offset>
+                                <AbsDimension x="0" y="-20" />
+                            </Offset>
+                        </Anchor>
+                    </Anchors>
+                </FontString>
+                
+                <!-- Scale Label -->
+                <FontString name="DConfigScaleLabel" inherits="DQuestButtonTitleGossip" text="Window Scale:" justifyH="LEFT">
+                    <Size>
+                        <AbsDimension x="150" y="20" />
+                    </Size>
+                    <Anchors>
+                        <Anchor point="TOP" relativeTo="DConfigInfoText" relativePoint="BOTTOM">
+                            <Offset>
+                                <AbsDimension x="-80" y="-20" />
+                            </Offset>
+                        </Anchor>
+                    </Anchors>
+                </FontString>
+                
+                <!-- Transparency Label -->
+                <FontString name="DConfigAlphaLabel" inherits="DQuestButtonTitleGossip" text="Transparency:" justifyH="LEFT">
+                    <Size>
+                        <AbsDimension x="150" y="20" />
+                    </Size>
+                    <Anchors>
+                        <Anchor point="TOP" relativeTo="DConfigScaleLabel" relativePoint="BOTTOM">
+                            <Offset>
+                                <AbsDimension x="0" y="-35" />
+                            </Offset>
+                        </Anchor>
+                    </Anchors>
+                </FontString>
+                
+                <!-- Font Size Label -->
+                <FontString name="DConfigFontLabel" inherits="DQuestButtonTitleGossip" text="Font Size:" justifyH="LEFT">
+                    <Size>
+                        <AbsDimension x="150" y="20" />
+                    </Size>
+                    <Anchors>
+                        <Anchor point="TOP" relativeTo="DConfigAlphaLabel" relativePoint="BOTTOM">
+                            <Offset>
+                                <AbsDimension x="0" y="-35" />
+                            </Offset>
+                        </Anchor>
+                    </Anchors>
+                </FontString>
+            </Layer>
+        </Layers>
+        <Frames>
+            <!-- Scale EditBox -->
+            <EditBox name="DConfigScaleEditBox" inherits="DConfigEditBoxTemplate">
+                <Anchors>
+                    <Anchor point="LEFT" relativeTo="DConfigScaleLabel" relativePoint="RIGHT">
+                        <Offset>
+                            <AbsDimension x="10" y="0" />
+                        </Offset>
+                    </Anchor>
+                </Anchors>
+                <Scripts>
+                    <OnEnterPressed>
+                        DConfigScaleEditBox_OnEnterPressed();
+                    </OnEnterPressed>
+                </Scripts>
+            </EditBox>
+
+            <!-- Transparency EditBox -->
+            <EditBox name="DConfigAlphaEditBox" inherits="DConfigEditBoxTemplate">
+                <Anchors>
+                    <Anchor point="LEFT" relativeTo="DConfigAlphaLabel" relativePoint="RIGHT">
+                        <Offset>
+                            <AbsDimension x="10" y="0" />
+                        </Offset>
+                    </Anchor>
+                </Anchors>
+                <Scripts>
+                    <OnEnterPressed>
+                        DConfigAlphaEditBox_OnEnterPressed();
+                    </OnEnterPressed>
+                </Scripts>
+            </EditBox>
+
+            <!-- Font Size EditBox -->
+            <EditBox name="DConfigFontEditBox" inherits="DConfigEditBoxTemplate">
+                <Anchors>
+                    <Anchor point="LEFT" relativeTo="DConfigFontLabel" relativePoint="RIGHT">
+                        <Offset>
+                            <AbsDimension x="10" y="0" />
+                        </Offset>
+                    </Anchor>
+                </Anchors>
+                <Scripts>
+                    <OnEnterPressed>
+                        DConfigFontEditBox_OnEnterPressed();
+                    </OnEnterPressed>
+                </Scripts>
+            </EditBox>
+
+            <!-- Reset Button -->
+            <Button name="DConfigResetButton" inherits="DUIPanelButtonTemplate" text="RESET TO DEFAULT">
+                <Size>
+                    <AbsDimension x="180" y="35" />
+                </Size>
+                <Anchors>
+                    <Anchor point="BOTTOM" relativeTo="DConfigFrame" relativePoint="BOTTOM">
+                        <Offset>
+                            <AbsDimension x="-90" y="80" />
+                        </Offset>
+                    </Anchor>
+                </Anchors>
+                <Scripts>
+                    <OnClick>
+                        DConfigResetButton_OnClick();
+                    </OnClick>
+                </Scripts>
+            </Button>
+
+            <!-- Close Button -->
+            <Button name="DConfigCloseButton" inherits="DUIPanelButtonTemplate" text="CLOSE">
+                <Size>
+                    <AbsDimension x="100" y="35" />
+                </Size>
+                <Anchors>
+                    <Anchor point="BOTTOM" relativeTo="DConfigFrame" relativePoint="BOTTOM">
+                        <Offset>
+                            <AbsDimension x="90" y="80" />
+                        </Offset>
+                    </Anchor>
+                </Anchors>
+                <Scripts>
+                    <OnClick>
+                        DConfigCloseButton_OnClick();
+                    </OnClick>
+                </Scripts>
+            </Button>
+
+            <!-- Info Text -->
+            <Frame name="DConfigInfoFrame">
+                <Size>
+                    <AbsDimension x="350" y="150" />
+                </Size>
+                <Anchors>
+                    <Anchor point="TOP" relativeTo="DConfigFontEditBox" relativePoint="BOTTOM">
+                        <Offset>
+                            <AbsDimension x="0" y="-30" />
+                        </Offset>
+                    </Anchor>
+                </Anchors>
+                <Layers>
+                    <Layer level="OVERLAY">
+                        <FontString name="DConfigInfoText" inherits="DQuestFont" justifyH="LEFT" justifyV="TOP">
+                            <Size>
+                                <AbsDimension x="330" y="140" />
+                            </Size>
+                            <Anchors>
+                                <Anchor point="TOPLEFT">
+                                    <Offset>
+                                        <AbsDimension x="10" y="-5" />
+                                    </Offset>
+                                </Anchor>
+                            </Anchors>
+                        </FontString>
+                    </Layer>
+                </Layers>
+            </Frame>
+        </Frames>
+        <Scripts>
+            <OnLoad>
+                DConfigFrame_OnLoad();
+            </OnLoad>
+            <OnShow>
+                DConfigFrame_OnShow();
+            </OnShow>
+            <OnHide>
+                DConfigFrame_OnHide();
+            </OnHide>
+        </Scripts>
+    </Frame>
+</Ui>

--- a/src/frames/gossipFrame/gossip.frame.xml
+++ b/src/frames/gossipFrame/gossip.frame.xml
@@ -589,6 +589,12 @@
             <OnMouseWheel>
                 return;
             </OnMouseWheel>
+            <OnMouseDown>
+                DGossipFrame_OnMouseDown();
+            </OnMouseDown>
+            <OnMouseUp>
+                DGossipFrame_OnMouseUp();
+            </OnMouseUp>
         </Scripts>
     </Frame>
 </Ui>

--- a/src/frames/questFrame/quest.frame.xml
+++ b/src/frames/questFrame/quest.frame.xml
@@ -1299,9 +1299,18 @@
             <OnHide>
                 DQuestFrame_OnHide();
             </OnHide>
+            <OnKeyDown>
+                DQuestFrame_OnKeyDown();
+            </OnKeyDown>
             <OnMouseWheel>
                 return;
             </OnMouseWheel>
+            <OnMouseDown>
+                DQuestFrame_OnMouseDown();
+            </OnMouseDown>
+            <OnMouseUp>
+                DQuestFrame_OnMouseUp();
+            </OnMouseUp>
         </Scripts>
     </Frame>
 </Ui>


### PR DESCRIPTION
- Implemented a new configuration frame for DialogUI with options to adjust scale, transparency, and font size.
- Added functionality to save and load configuration settings.
- Enhanced the gossip and quest frames to support dragging and position saving/loading.
- Updated XML files to define the layout and elements of the configuration frame.
- Integrated commands for resetting positions and toggling the configuration window.
- Ensured compatibility with existing frames by hiding default UI elements and applying transparency settings.